### PR TITLE
Alternative Skillpoint View

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The folder must be named **`USPF`** and contain `USPF.txt` at the top level.
 | `/uspfmenu` | Open **LibAddonMenu** settings (fonts, colors, sort order, overrides) |
 | `/uspdun` | Show or hide the **dungeon account** window (see below) |
 
-You can also bind the main window via **Controls → Urich's Skill Point Finder**.
+You can also bind both windows under **Controls → Urich's Skill Point Finder** (main USPF and **Dungeon account window**).
 
 ## Main window — existing functionality
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Data updates when you play on the **current** character (quests, achievements, s
 
 A separate window focused on **one dungeon at a time** across **all character slots** on the account:
 
-1. Choose either a **public dungeon** or a **group dungeon** from the two dropdowns (the lists match USPF’s internal data). Selecting one clears the other.
+1. Choose either a **public dungeon** or a **group dungeon** from the two dropdowns (the lists match USPF’s internal data). Public entries show **dungeon name (zone name)**. Use the sort button below the public list to order them **by dungeon name** or **by zone name** (saved account-wide). Selecting one dropdown clears the other.
 2. Click **List characters** (enabled only after a dungeon is selected).
 3. The list shows **every character** returned by the game’s character list (`GetNumCharacters` / `GetCharacterInfo`), in slot order.
 4. For each name, **Skill point** shows:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,63 @@
+# Urich's Skill Point Finder (USPF)
+
+ESO addon that tracks **where skill points can come from** on each character (quests, skyshards, dungeons, achievements, etc.) and compares progress against account-wide totals.
+
+## Requirements
+
+- **LibAddonMenu-2.0**
+- **LibTableFunctions-1.0**
+
+Install these in the same `AddOns` folder as USPF (for example from [ESOUI](https://www.esoui.com/) or the Minion addon manager).
+
+## Installation
+
+1. Copy the **`USPF`** folder into your ESO addons directory, for example:
+   - **Windows:** `Documents\Elder Scrolls Online\live\AddOns`
+   - **macOS:** `~/Documents/Elder Scrolls Online/live/AddOns`
+2. Ensure the libraries above are installed and enabled.
+3. In-game: **Settings → Add-Ons** → enable **Urich's Skill Point Finder** (and dependencies). Reload UI if prompted.
+
+The folder must be named **`USPF`** and contain `USPF.txt` at the top level.
+
+## Slash commands
+
+| Command | Action |
+|--------|--------|
+| `/uspf` | Show or hide the **main** USPF window |
+| `/uspf help` | Print slash-command help in chat |
+| `/uspfmenu` | Open **LibAddonMenu** settings (fonts, colors, sort order, overrides) |
+| `/uspdun` | Show or hide the **dungeon account** window (see below) |
+
+You can also bind the main window via **Controls → Urich's Skill Point Finder**.
+
+## Main window — existing functionality
+
+The primary UI is opened with **`/uspf`**. It includes:
+
+- **Character selector** — Pick which character’s saved snapshot to view. Only characters that have logged in at least once with USPF enabled have complete data; tooltips explain this elsewhere in the UI.
+- **General skill points** — Level, main quest, tutorial, Alliance War rank, Maelstrom Arena, Endless Archive quest, Folium Discognitum, etc., with progress vs maximum where applicable.
+- **Storyline quests & skyshards** — Per-zone zone quest progress and skyshard counts (including totals).
+- **Group dungeon quests** — One skill point per dungeon from the listed dungeon quest; shown in two columns, sortable via settings.
+- **Public dungeon group boss events** — One skill point per public dungeon from the relevant achievement; sortable via settings.
+- **Character total** — Sum of tracked sources vs theoretical maximum, plus unassigned skill points when known.
+
+Data updates when you play on the **current** character (quests, achievements, skyshards, level, etc.); other characters show the last values saved when you last played them with the addon running.
+
+**Settings** (`/uspfmenu`): fonts for each section, colors for complete/incomplete/progress states, table sort modes, and optional overrides (e.g. tutorial / Folium Discognitum).
+
+## Dungeon account window — new functionality (`/uspdun`)
+
+A separate window focused on **one dungeon at a time** across **all character slots** on the account:
+
+1. Choose either a **public dungeon** or a **group dungeon** from the two dropdowns (the lists match USPF’s internal data). Selecting one clears the other.
+2. Click **List characters** (enabled only after a dungeon is selected).
+3. The list shows **every character** returned by the game’s character list (`GetNumCharacters` / `GetCharacterInfo`), in slot order.
+4. For each name, **Skill point** shows:
+   - **Yes** / **No** (green / red) when USPF has saved data for that character for that dungeon (same rules as the main tables: group = dungeon quest complete, public = achievement complete).
+   - **No saved data** when that character has never logged in with USPF, so there is no snapshot in saved variables yet.
+
+This does not replace the main window; it reuses the same saved data (`USPF_Settings` / per-character point tables).
+
+## License / attribution
+
+Not created by, affiliated with, or sponsored by ZeniMax Media Inc. See `USPF/USPF.txt` for the standard ESO add-on terms reference.

--- a/USPF/USPF.lua
+++ b/USPF/USPF.lua
@@ -59,6 +59,7 @@ USPF.defaults = {
 	charInfo = {},
 	settings = {},
 	ptsData = {},
+	dunPDSortBy = "dungeon",
 }
 
 
@@ -1303,7 +1304,54 @@ function USPF:ToggleWindow()
 	SCENE_MANAGER:ToggleTopLevel(USPF_GUI)
 end
 
-local function USPF_BuildDunCombos()
+local function USPF_GetPDDungeonDisplayName(d)
+	return zf("<<C:1>>", GZNBId(d.id))
+end
+
+local function USPF_GetPDZoneDisplayName(d)
+	return zf("<<C:1>>", GZNBId(USPF.data.ZId.ZN[d.zone]))
+end
+
+local function USPF_GetPDComboLabel(d)
+	return zf("<<C:1>> (<<C:2>>)", GZNBId(d.id), GZNBId(USPF.data.ZId.ZN[d.zone]))
+end
+
+local function USPF_GetGDComboLabel(d)
+	return zf("<<C:1>>", GZNBId(d.id))
+end
+
+local function USPF_BuildSortedPDList()
+	local pdList = {}
+	for _, d in ipairs(USPF.data.PD) do
+		table.insert(pdList, d)
+	end
+	local sortMode = USPF.sVar.dunPDSortBy or "dungeon"
+	table.sort(pdList, function(a, b)
+		local da, db = USPF_GetPDDungeonDisplayName(a), USPF_GetPDDungeonDisplayName(b)
+		local za, zb = USPF_GetPDZoneDisplayName(a), USPF_GetPDZoneDisplayName(b)
+		local la, lb = zo_strlower(da), zo_strlower(db)
+		local lza, lzb = zo_strlower(za), zo_strlower(zb)
+		if sortMode == "zone" then
+			if lza ~= lzb then return lza < lzb end
+			return la < lb
+		end
+		if la ~= lb then return la < lb end
+		return lza < lzb
+	end)
+	return pdList
+end
+
+local function USPF_FindGDEntry(key)
+	for _, d in ipairs(USPF.data.GD) do
+		if d.key == key then return d end
+	end
+	return nil
+end
+
+local function USPF_BuildDunCombos(preserveSelection)
+	local savedPDKey = preserveSelection and USPF.dunPDKey or nil
+	local savedGDKey = preserveSelection and USPF.dunGDKey or nil
+
 	local pdCombo = USPF_DUN_GUI_Body_PDCombo.comboBox or ZO_ComboBox_ObjectFromContainer(USPF_DUN_GUI_Body_PDCombo)
 	USPF_DUN_GUI_Body_PDCombo.comboBox = pdCombo
 	local gdCombo = USPF_DUN_GUI_Body_GDCombo.comboBox or ZO_ComboBox_ObjectFromContainer(USPF_DUN_GUI_Body_GDCombo)
@@ -1322,8 +1370,8 @@ local function USPF_BuildDunCombos()
 		USPF:UpdateDunButtonState()
 	end))
 
-	for _, d in ipairs(USPF.data.PD) do
-		local label = zf("<<C:1>>", GZNBId(d.id))
+	for _, d in ipairs(USPF_BuildSortedPDList()) do
+		local label = USPF_GetPDComboLabel(d)
 		pdCombo:AddItem(pdCombo:CreateItemEntry(label, function()
 			USPF.dunPDKey = d.key
 			USPF.dunGDKey = nil
@@ -1339,7 +1387,7 @@ local function USPF_BuildDunCombos()
 	end))
 
 	for _, d in ipairs(USPF.data.GD) do
-		local label = zf("<<C:1>>", GZNBId(d.id))
+		local label = USPF_GetGDComboLabel(d)
 		gdCombo:AddItem(gdCombo:CreateItemEntry(label, function()
 			USPF.dunGDKey = d.key
 			USPF.dunPDKey = nil
@@ -1349,10 +1397,45 @@ local function USPF_BuildDunCombos()
 		end))
 	end
 
-	pdCombo:SetSelectedItem(selPD)
-	gdCombo:SetSelectedItem(selGD)
-	USPF.dunPDKey = nil
-	USPF.dunGDKey = nil
+	if savedPDKey then
+		local pdEntry = nil
+		for _, d in ipairs(USPF.data.PD) do
+			if d.key == savedPDKey then
+				pdEntry = d
+				break
+			end
+		end
+		if pdEntry then
+			pdCombo:SetSelectedItem(USPF_GetPDComboLabel(pdEntry))
+			gdCombo:SetSelectedItem(selGD)
+			USPF.dunPDKey = savedPDKey
+			USPF.dunGDKey = nil
+		else
+			pdCombo:SetSelectedItem(selPD)
+			gdCombo:SetSelectedItem(selGD)
+			USPF.dunPDKey = nil
+			USPF.dunGDKey = nil
+		end
+	elseif savedGDKey then
+		local gdEntry = USPF_FindGDEntry(savedGDKey)
+		if gdEntry then
+			gdCombo:SetSelectedItem(USPF_GetGDComboLabel(gdEntry))
+			pdCombo:SetSelectedItem(selPD)
+			USPF.dunGDKey = savedGDKey
+			USPF.dunPDKey = nil
+		else
+			pdCombo:SetSelectedItem(selPD)
+			gdCombo:SetSelectedItem(selGD)
+			USPF.dunPDKey = nil
+			USPF.dunGDKey = nil
+		end
+	else
+		pdCombo:SetSelectedItem(selPD)
+		gdCombo:SetSelectedItem(selGD)
+		USPF.dunPDKey = nil
+		USPF.dunGDKey = nil
+	end
+
 	USPF:UpdateDunButtonState()
 end
 
@@ -1398,11 +1481,27 @@ end
 function USPF:ToggleDunWindow()
 	USPF.dunActive = not USPF.dunActive
 	if USPF.dunActive then
+		USPF:UpdateDunPDSortButtonLabel()
 		USPF_UpdateListData(USPF_DUN_GUI_Body_ListHolder, {
 			{ header = true, source = GS(USPF_DUN_CHAR_NAME), progress = GS(USPF_DUN_STATUS) },
 		})
 	end
 	SCENE_MANAGER:ToggleTopLevel(USPF_DUN_GUI)
+end
+
+function USPF:UpdateDunPDSortButtonLabel()
+	if USPF.sVar.dunPDSortBy == "zone" then
+		USPF_DUN_GUI_Body_PDSortBtn:SetText(GS(USPF_DUN_PD_SORT_ZONE))
+	else
+		USPF_DUN_GUI_Body_PDSortBtn:SetText(GS(USPF_DUN_PD_SORT_DUNGEON))
+	end
+end
+
+function USPF:CycleDunPDSort()
+	USPF.sVar.dunPDSortBy = USPF.sVar.dunPDSortBy == "zone" and "dungeon" or "zone"
+	USPF:UpdateDunPDSortButtonLabel()
+	USPF_BuildDunCombos(true)
+	PlaySound(SOUNDS.DEFAULT_CLICK)
 end
 
 function USPF:SetupDunWindow()
@@ -1412,13 +1511,15 @@ function USPF:SetupDunWindow()
 	USPF_DUN_GUI_Body_Label_PD:SetFont(titleFont .. "|16")
 	USPF_DUN_GUI_Body_Label_GD:SetFont(titleFont .. "|16")
 	USPF_DUN_GUI_Body_ListBtn:SetFont(rowFont)
+	USPF_DUN_GUI_Body_PDSortBtn:SetFont(rowFont)
 
 	ZO_ScrollList_AddDataType(USPF_DUN_GUI_Body_ListHolder, USPF_LIST_DATA_TYPE, "USPF_GeneralTemplate", 18, function(control, data)
 		USPF:SetupGeneralItem(control, data)
 	end)
 	ZO_ScrollList_AddDataType(USPF_DUN_GUI_Body_ListHolder, USPF_LIST_SEPARATOR_TYPE, "USPF_ListSeparator", 2, function() end)
 
-	USPF_BuildDunCombos()
+	USPF:UpdateDunPDSortButtonLabel()
+	USPF_BuildDunCombos(false)
 end
 
 
@@ -1711,6 +1812,10 @@ local function USPF_Initialized(eventCode, addonName)
 		USPF.sVar = ZO_SavedVars:NewAccountWide("USPF_Settings", USPF.version, nil, USPF.defaults)
 	else
 		USPF.sVar = ZO_SavedVars:NewAccountWide("USPF_Settings", USPF.version, world, USPF.defaults)
+	end
+
+	if USPF.sVar.dunPDSortBy ~= "dungeon" and USPF.sVar.dunPDSortBy ~= "zone" then
+		USPF.sVar.dunPDSortBy = "dungeon"
 	end
 
 	--Run the startup routine.

--- a/USPF/USPF.lua
+++ b/USPF/USPF.lua
@@ -1484,14 +1484,19 @@ function USPF:OnDunListButton()
 end
 
 function USPF:ToggleDunWindow()
-	USPF.dunActive = not USPF.dunActive
-	if USPF.dunActive then
+	-- Use Show/Hide from actual visibility instead of ToggleTopLevel. ToggleTopLevel can desync from
+	-- IsHidden() (keybind + close button), so the first press or click appears to do nothing.
+	if USPF_DUN_GUI:IsHidden() then
+		USPF.dunActive = true
 		USPF:UpdateDunPDSortButtonLabel()
 		USPF_UpdateListData(USPF_DUN_GUI_Body_ListHolder, {
 			{ header = true, source = GS(USPF_DUN_CHAR_NAME), progress = GS(USPF_DUN_STATUS) },
 		}, true)
+		SCENE_MANAGER:ShowTopLevel(USPF_DUN_GUI)
+	else
+		USPF.dunActive = false
+		SCENE_MANAGER:HideTopLevel(USPF_DUN_GUI)
 	end
-	SCENE_MANAGER:ToggleTopLevel(USPF_DUN_GUI)
 end
 
 function USPF:UpdateDunPDSortButtonLabel()

--- a/USPF/USPF.lua
+++ b/USPF/USPF.lua
@@ -1718,6 +1718,7 @@ local function USPF_Initialized(eventCode, addonName)
 
 	--Create the keybind(s).
 	ZO_CreateStringId("SI_BINDING_NAME_USPF_TOGGLE", "Show Skill Point Finder")
+	ZO_CreateStringId("SI_BINDING_NAME_USPF_DUN_TOGGLE", "Dungeon account window")
 
 	--Register the slash commands.
 	SLASH_COMMANDS["/uspf"] = function(keyWord, argument)

--- a/USPF/USPF.lua
+++ b/USPF/USPF.lua
@@ -1171,7 +1171,10 @@ local function USPF_UpdateListData(control, data, fixedViewport)
 	table.insert(dataList, ZO_ScrollList_CreateDataEntry(USPF_LIST_SEPARATOR_TYPE, {}))
 	ZO_ScrollList_Commit(control)
 	if fixedViewport then
-		ZO_ScrollList_ResetToTopLevel(control)
+		-- Not all API versions expose ZO_ScrollList_ResetToTopLevel (nil would error as "function expected").
+		if ZO_ScrollList_ResetToTopLevel then
+			ZO_ScrollList_ResetToTopLevel(control)
+		end
 	else
 		control:SetHeight(18 * #data + 4)
 	end

--- a/USPF/USPF.lua
+++ b/USPF/USPF.lua
@@ -1159,7 +1159,8 @@ local function USPF_FormatProgress(current, total, colors)
 	return strF("%s%d/%d|r", color, current, total)
 end
 
-local function USPF_UpdateListData(control, data)
+--- @param fixedViewport boolean|nil If true, do not resize the control to content height. Use for scroll lists with a fixed pixel height in XML (ZO_ScrollList viewport); resizing to full content breaks layout until the user scrolls.
+local function USPF_UpdateListData(control, data, fixedViewport)
 	local dataList = ZO_ScrollList_GetDataList(control)
 	ZO_ScrollList_Clear(control)
 	table.insert(dataList, ZO_ScrollList_CreateDataEntry(USPF_LIST_DATA_TYPE, data[1])) -- header
@@ -1169,7 +1170,11 @@ local function USPF_UpdateListData(control, data)
 	end
 	table.insert(dataList, ZO_ScrollList_CreateDataEntry(USPF_LIST_SEPARATOR_TYPE, {}))
 	ZO_ScrollList_Commit(control)
-	control:SetHeight(18 * #data + 4)
+	if fixedViewport then
+		ZO_ScrollList_ResetToTopLevel(control)
+	else
+		control:SetHeight(18 * #data + 4)
+	end
 end
 
 function USPF:UpdateDataLines()
@@ -1469,7 +1474,7 @@ function USPF:RefreshDunCharacterList()
 			progress = progressText,
 		})
 	end
-	USPF_UpdateListData(USPF_DUN_GUI_Body_ListHolder, lines)
+	USPF_UpdateListData(USPF_DUN_GUI_Body_ListHolder, lines, true)
 end
 
 function USPF:OnDunListButton()
@@ -1484,7 +1489,7 @@ function USPF:ToggleDunWindow()
 		USPF:UpdateDunPDSortButtonLabel()
 		USPF_UpdateListData(USPF_DUN_GUI_Body_ListHolder, {
 			{ header = true, source = GS(USPF_DUN_CHAR_NAME), progress = GS(USPF_DUN_STATUS) },
-		})
+		}, true)
 	end
 	SCENE_MANAGER:ToggleTopLevel(USPF_DUN_GUI)
 end

--- a/USPF/USPF.lua
+++ b/USPF/USPF.lua
@@ -2,6 +2,9 @@ if USPF == nil then USPF = {} end
 USPF.AddonName = "USPF"
 USPF.version = 1.0
 USPF.active = false
+USPF.dunActive = false
+USPF.dunPDKey = nil
+USPF.dunGDKey = nil
 USPF.GUI = {}
 local selectedChar = GetCurrentCharacterId()
 local currentCharName = nil
@@ -1300,6 +1303,124 @@ function USPF:ToggleWindow()
 	SCENE_MANAGER:ToggleTopLevel(USPF_GUI)
 end
 
+local function USPF_BuildDunCombos()
+	local pdCombo = USPF_DUN_GUI_Body_PDCombo.comboBox or ZO_ComboBox_ObjectFromContainer(USPF_DUN_GUI_Body_PDCombo)
+	USPF_DUN_GUI_Body_PDCombo.comboBox = pdCombo
+	local gdCombo = USPF_DUN_GUI_Body_GDCombo.comboBox or ZO_ComboBox_ObjectFromContainer(USPF_DUN_GUI_Body_GDCombo)
+	USPF_DUN_GUI_Body_GDCombo.comboBox = gdCombo
+
+	local selPD = GS(USPF_DUN_SELECT_PD)
+	local selGD = GS(USPF_DUN_SELECT_GD)
+
+	pdCombo:ClearItems()
+	gdCombo:ClearItems()
+	pdCombo:SetSortsItems(false)
+	gdCombo:SetSortsItems(false)
+
+	pdCombo:AddItem(pdCombo:CreateItemEntry(selPD, function()
+		USPF.dunPDKey = nil
+		USPF:UpdateDunButtonState()
+	end))
+
+	for _, d in ipairs(USPF.data.PD) do
+		local label = zf("<<C:1>>", GZNBId(d.id))
+		pdCombo:AddItem(pdCombo:CreateItemEntry(label, function()
+			USPF.dunPDKey = d.key
+			USPF.dunGDKey = nil
+			gdCombo:SetSelectedItem(selGD)
+			USPF:UpdateDunButtonState()
+			PlaySound(SOUNDS.POSITIVE_CLICK)
+		end))
+	end
+
+	gdCombo:AddItem(gdCombo:CreateItemEntry(selGD, function()
+		USPF.dunGDKey = nil
+		USPF:UpdateDunButtonState()
+	end))
+
+	for _, d in ipairs(USPF.data.GD) do
+		local label = zf("<<C:1>>", GZNBId(d.id))
+		gdCombo:AddItem(gdCombo:CreateItemEntry(label, function()
+			USPF.dunGDKey = d.key
+			USPF.dunPDKey = nil
+			pdCombo:SetSelectedItem(selPD)
+			USPF:UpdateDunButtonState()
+			PlaySound(SOUNDS.POSITIVE_CLICK)
+		end))
+	end
+
+	pdCombo:SetSelectedItem(selPD)
+	gdCombo:SetSelectedItem(selGD)
+	USPF.dunPDKey = nil
+	USPF.dunGDKey = nil
+	USPF:UpdateDunButtonState()
+end
+
+function USPF:UpdateDunButtonState()
+	local ok = USPF.dunPDKey ~= nil or USPF.dunGDKey ~= nil
+	USPF_DUN_GUI_Body_ListBtn:SetEnabled(ok)
+end
+
+function USPF:RefreshDunCharacterList()
+	local lines = {
+		{ header = true, source = GS(USPF_DUN_CHAR_NAME), progress = GS(USPF_DUN_STATUS) },
+	}
+	for i = 1, GetNumCharacters() do
+		local name, _, _, _, _, _, charId, _ = GetCharacterInfo(i)
+		local charName = zf("<<1>>", name)
+		local pts = USPF.sVar.ptsData[charId]
+		local progressText
+		if not pts then
+			progressText = GS(USPF_DUN_NO_DATA)
+		elseif USPF.dunPDKey then
+			local v = pts.PD and pts.PD[USPF.dunPDKey]
+			progressText = (v == 1) and USPF_GreenText(GS(USPF_DUN_HAS_SP)) or USPF_RedText(GS(USPF_DUN_MISSING_SP))
+		elseif USPF.dunGDKey then
+			local v = pts.GD and pts.GD[USPF.dunGDKey]
+			progressText = (v == 1) and USPF_GreenText(GS(USPF_DUN_HAS_SP)) or USPF_RedText(GS(USPF_DUN_MISSING_SP))
+		else
+			progressText = GS(USPF_DUN_UNKNOWN)
+		end
+		table.insert(lines, {
+			source = charName,
+			progress = progressText,
+		})
+	end
+	USPF_UpdateListData(USPF_DUN_GUI_Body_ListHolder, lines)
+end
+
+function USPF:OnDunListButton()
+	if not USPF.dunPDKey and not USPF.dunGDKey then return end
+	USPF:RefreshDunCharacterList()
+	PlaySound(SOUNDS.POSITIVE_CLICK)
+end
+
+function USPF:ToggleDunWindow()
+	USPF.dunActive = not USPF.dunActive
+	if USPF.dunActive then
+		USPF_UpdateListData(USPF_DUN_GUI_Body_ListHolder, {
+			{ header = true, source = GS(USPF_DUN_CHAR_NAME), progress = GS(USPF_DUN_STATUS) },
+		})
+	end
+	SCENE_MANAGER:ToggleTopLevel(USPF_DUN_GUI)
+end
+
+function USPF:SetupDunWindow()
+	local titleFont = USPF.Options.Font.Fonts[USPF.settings.title.font]
+	local rowFont = titleFont .. "|14"
+	USPF_DUN_GUI_Header_Title:SetFont(titleFont .. "|24")
+	USPF_DUN_GUI_Body_Label_PD:SetFont(titleFont .. "|16")
+	USPF_DUN_GUI_Body_Label_GD:SetFont(titleFont .. "|16")
+	USPF_DUN_GUI_Body_ListBtn:SetFont(rowFont)
+
+	ZO_ScrollList_AddDataType(USPF_DUN_GUI_Body_ListHolder, USPF_LIST_DATA_TYPE, "USPF_GeneralTemplate", 18, function(control, data)
+		USPF:SetupGeneralItem(control, data)
+	end)
+	ZO_ScrollList_AddDataType(USPF_DUN_GUI_Body_ListHolder, USPF_LIST_SEPARATOR_TYPE, "USPF_ListSeparator", 2, function() end)
+
+	USPF_BuildDunCombos()
+end
+
 
 function USPF:SetupValues()
 	USPF_RefreshData()
@@ -1609,6 +1730,10 @@ local function USPF_Initialized(eventCode, addonName)
 		end
 	end
 
+	SLASH_COMMANDS["/uspdun"] = function()
+		USPF:ToggleDunWindow()
+	end
+
 	local charId = GCCId()
 
 	--Load the character settings.
@@ -1622,8 +1747,10 @@ local function USPF_Initialized(eventCode, addonName)
 
 	--Call startup routine.
 	USPF:SetupValues()
+	USPF:SetupDunWindow()
 
 	SCENE_MANAGER:RegisterTopLevel(USPF_GUI, locksUIMode)
+	SCENE_MANAGER:RegisterTopLevel(USPF_DUN_GUI, locksUIMode)
 
 	--Create the event handlers.
 	EVENT_MANAGER:RegisterForEvent(USPF.AddonName, EVENT_SKILL_POINTS_CHANGED, USPF_SkillPointsUpdate)

--- a/USPF/USPF.txt
+++ b/USPF/USPF.txt
@@ -1,7 +1,7 @@
 ## Title: Urich's Skill Point Finder
-## Author: Yachoor, tim99, Originally Urich & Onigar
-## Version: 7.5.0
-## AddOnVersion: 70500
+## Author: Yachoor, tim99, Pryowin, Originally Urich & Onigar
+## Version: 8.0.0
+## AddOnVersion: 80000
 ## APIVersion: 101048
 ## SavedVariables: USPF_Settings
 ## DependsOn: LibAddonMenu-2.0 LibTableFunctions-1.0

--- a/USPF/USPF.xml
+++ b/USPF/USPF.xml
@@ -268,7 +268,7 @@
 		</TopLevelControl>
 
 		<TopLevelControl name="USPF_DUN_GUI" mouseEnabled="true" movable="true" hidden="true" allowBringToTop="true" tier="HIGH">
-			<Dimensions x="440" y="420" />
+			<Dimensions x="440" y="458" />
 			<Anchor point="CENTER" relativeTo="GuiRoot" relativePoint="CENTER" offsetX="0" offsetY="0" />
 
 			<Controls>
@@ -308,9 +308,15 @@
 							<Anchor point="TOPLEFT" relativeTo="$(parent)_Label_PD" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="4" />
 						</Control>
 
+						<Button name="$(parent)_PDSortBtn" inherits="ZO_DefaultButton" text="USPF_DUN_PD_SORT_DUNGEON">
+							<Dimensions x="400" y="28" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)_PDCombo" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="6" />
+							<OnMouseUp>USPF:CycleDunPDSort()</OnMouseUp>
+						</Button>
+
 						<Label name="$(parent)_Label_GD" font="$(ANTIQUE_FONT)|16" text="USPF_DUN_LABEL_GD" horizontalAlignment="LEFT" verticalAlignment="CENTER">
 							<Dimensions x="424" y="20" />
-							<Anchor point="TOPLEFT" relativeTo="$(parent)_PDCombo" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="10" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)_PDSortBtn" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="10" />
 						</Label>
 						<Control name="$(parent)_GDCombo" inherits="ZO_ComboBox" tier="HIGH">
 							<Dimensions x="400" y="26" />

--- a/USPF/USPF.xml
+++ b/USPF/USPF.xml
@@ -266,5 +266,70 @@
 				</Control>
 			</Controls>
 		</TopLevelControl>
+
+		<TopLevelControl name="USPF_DUN_GUI" mouseEnabled="true" movable="true" hidden="true" allowBringToTop="true" tier="HIGH">
+			<Dimensions x="440" y="420" />
+			<Anchor point="CENTER" relativeTo="GuiRoot" relativePoint="CENTER" offsetX="0" offsetY="0" />
+
+			<Controls>
+				<Backdrop name="$(parent)_BG" inherits="ZO_DefaultBackdrop" centerColor="FFFFFFFF" />
+
+				<Control name="$(parent)_Header" resizeToFitConstrains="X">
+					<Dimensions y="36" />
+					<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0" />
+					<Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="0" offsetY="0" />
+
+					<Controls>
+						<Button name="$(parent)_Hide">
+							<Anchor point="TOPRIGHT" relativeTo="$(parent)" relativePoint="TOPRIGHT" offsetX="-6" offsetY="6" />
+							<OnMouseUp>USPF:ToggleDunWindow()</OnMouseUp>
+							<Dimensions x="25" y="25" />
+							<Textures normal="/esoui/art/buttons/decline_up.dds" pressed="/esoui/art/buttons/decline_down.dds" mouseOver="/esoui/art/buttons/decline_over.dds" />
+						</Button>
+						<Label name="$(parent)_Title" font="$(ANTIQUE_FONT)|24" text="USPF_DUN_WINDOW_TITLE" horizontalAlignment="CENTER" verticalAlignment="CENTER">
+							<Dimensions y="30" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="4" />
+							<Anchor point="TOPRIGHT" relativeTo="$(parent)_Hide" relativePoint="TOPLEFT" offsetX="-4" offsetY="0" />
+						</Label>
+					</Controls>
+				</Control>
+
+				<Control name="$(parent)_Body">
+					<Anchor point="TOPLEFT" relativeTo="$(parent)_Header" relativePoint="BOTTOMLEFT" offsetX="8" offsetY="10" />
+					<Anchor point="TOPRIGHT" relativeTo="$(parent)_Header" relativePoint="BOTTOMRIGHT" offsetX="-8" offsetY="10" />
+
+					<Controls>
+						<Label name="$(parent)_Label_PD" font="$(ANTIQUE_FONT)|16" text="USPF_DUN_LABEL_PD" horizontalAlignment="LEFT" verticalAlignment="CENTER">
+							<Dimensions x="424" y="20" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)" relativePoint="TOPLEFT" offsetX="0" offsetY="0" />
+						</Label>
+						<Control name="$(parent)_PDCombo" inherits="ZO_ComboBox" tier="HIGH">
+							<Dimensions x="400" y="26" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)_Label_PD" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="4" />
+						</Control>
+
+						<Label name="$(parent)_Label_GD" font="$(ANTIQUE_FONT)|16" text="USPF_DUN_LABEL_GD" horizontalAlignment="LEFT" verticalAlignment="CENTER">
+							<Dimensions x="424" y="20" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)_PDCombo" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="10" />
+						</Label>
+						<Control name="$(parent)_GDCombo" inherits="ZO_ComboBox" tier="HIGH">
+							<Dimensions x="400" y="26" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)_Label_GD" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="4" />
+						</Control>
+
+						<Button name="$(parent)_ListBtn" inherits="ZO_DefaultButton" text="USPF_DUN_LIST_BTN">
+							<Dimensions x="200" y="28" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)_GDCombo" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="12" />
+							<OnMouseUp>USPF:OnDunListButton()</OnMouseUp>
+						</Button>
+
+						<Control name="$(parent)_ListHolder" inherits="ZO_ScrollList">
+							<Dimensions x="400" y="220" />
+							<Anchor point="TOPLEFT" relativeTo="$(parent)_ListBtn" relativePoint="BOTTOMLEFT" offsetX="0" offsetY="12" />
+						</Control>
+					</Controls>
+				</Control>
+			</Controls>
+		</TopLevelControl>
 	</Controls>
 </GuiXml>

--- a/USPF/USPF_Menu.lua
+++ b/USPF/USPF_Menu.lua
@@ -1,8 +1,8 @@
 if USPF == nil then USPF = {} end
 
 local ADDON_NAME = GetString(USPF_GUI_TITLE)
-local ADDON_AUTHOR = "Urich"
-local ADDON_VERSION = "7.5.0"
+local ADDON_AUTHOR = "Yachoor, tim99, Pryowin; Originally Urich & Onigar"
+local ADDON_VERSION = "8.0.0"
 
 USPF.Options = {
 	Font = {

--- a/USPF/bindings.xml
+++ b/USPF/bindings.xml
@@ -4,6 +4,9 @@
 			<Action name="USPF_TOGGLE">
 				<Up>USPF:ToggleWindow()</Up>
 			</Action>
+			<Action name="USPF_DUN_TOGGLE">
+				<Up>USPF:ToggleDunWindow()</Up>
+			</Action>
 		</Category>
 	</Layer>
 </Bindings>

--- a/USPF/lang/de.lua
+++ b/USPF/lang/de.lua
@@ -85,6 +85,7 @@ SafeAddString(USPF_GUI_UNASSIGNED,						"nicht zugewiesen")
 
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE,				"Ein- / Ausblenden des USPF-Fensters")
+SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE,			"Ein- / Ausblenden des USPF-Verliese-Kontofensters")
 
 SafeAddString(USPF_GUI_ZN_MQ,							"Hauptaufgabe")
 

--- a/USPF/lang/de.lua
+++ b/USPF/lang/de.lua
@@ -86,6 +86,8 @@ SafeAddString(USPF_GUI_UNASSIGNED,						"nicht zugewiesen")
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE,				"Ein- / Ausblenden des USPF-Fensters")
 SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE,			"Ein- / Ausblenden des USPF-Verliese-Kontofensters")
+SafeAddString(USPF_DUN_PD_SORT_DUNGEON,				"Öffentliche Verliese: nach Verliesname sortieren")
+SafeAddString(USPF_DUN_PD_SORT_ZONE,				"Öffentliche Verliese: nach Zonenname sortieren")
 
 SafeAddString(USPF_GUI_ZN_MQ,							"Hauptaufgabe")
 

--- a/USPF/lang/fr.lua
+++ b/USPF/lang/fr.lua
@@ -86,6 +86,8 @@ SafeAddString(USPF_GUI_UNASSIGNED,						"non attribué")
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE,				"Afficher/masquer la fenêtre USPF.")
 SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE,			"Afficher/masquer la fenêtre USPF donjons (compte).")
+SafeAddString(USPF_DUN_PD_SORT_DUNGEON,				"Donjons publics : tri par nom de donjon")
+SafeAddString(USPF_DUN_PD_SORT_ZONE,				"Donjons publics : tri par nom de zone")
 
 SafeAddString(USPF_GUI_ZN_MQ,							"Quête Principale")
 

--- a/USPF/lang/fr.lua
+++ b/USPF/lang/fr.lua
@@ -85,6 +85,7 @@ SafeAddString(USPF_GUI_UNASSIGNED,						"non attribué")
 
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE,				"Afficher/masquer la fenêtre USPF.")
+SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE,			"Afficher/masquer la fenêtre USPF donjons (compte).")
 
 SafeAddString(USPF_GUI_ZN_MQ,							"Quête Principale")
 

--- a/USPF/lang/jp.lua
+++ b/USPF/lang/jp.lua
@@ -86,6 +86,8 @@ SafeAddString(USPF_GUI_UNASSIGNED,						"未割り当て")
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE,				"ウィンドウを表示/非表示にします。")
 SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE,			"ダンジョンアカウントウィンドウを表示/非表示にします。")
+SafeAddString(USPF_DUN_PD_SORT_DUNGEON,				"パブリックダンジョン: ダンジョン名で並べ替え")
+SafeAddString(USPF_DUN_PD_SORT_ZONE,				"パブリックダンジョン: ゾーン名で並べ替え")
 
 SafeAddString(USPF_GUI_ZN_MQ,							"メインクエスト")
 

--- a/USPF/lang/jp.lua
+++ b/USPF/lang/jp.lua
@@ -85,6 +85,7 @@ SafeAddString(USPF_GUI_UNASSIGNED,						"未割り当て")
 
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE,				"ウィンドウを表示/非表示にします。")
+SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE,			"ダンジョンアカウントウィンドウを表示/非表示にします。")
 
 SafeAddString(USPF_GUI_ZN_MQ,							"メインクエスト")
 

--- a/USPF/lang/ru.lua
+++ b/USPF/lang/ru.lua
@@ -85,6 +85,8 @@ SafeAddString(USPF_GUI_UNASSIGNED, "из них сейчас можно испо
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE, "Показать/скрыть окно USPF.")
 SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE, "Показать/скрыть окно подземелий USPF (аккаунт).")
+SafeAddString(USPF_DUN_PD_SORT_DUNGEON, "Открытые подземелья: сортировка по названию подземелья")
+SafeAddString(USPF_DUN_PD_SORT_ZONE, "Открытые подземелья: сортировка по названию зоны")
 
 SafeAddString(USPF_GUI_ZN_MQ, "Основная сюжетная линия")
 

--- a/USPF/lang/ru.lua
+++ b/USPF/lang/ru.lua
@@ -84,6 +84,7 @@ SafeAddString(USPF_GUI_UNASSIGNED, "из них сейчас можно испо
 
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE, "Показать/скрыть окно USPF.")
+SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE, "Показать/скрыть окно подземелий USPF (аккаунт).")
 
 SafeAddString(USPF_GUI_ZN_MQ, "Основная сюжетная линия")
 

--- a/USPF/lang/strings.lua
+++ b/USPF/lang/strings.lua
@@ -85,6 +85,7 @@ local strings = {
 
 
 	SI_BINDING_NAME_USPF_TOGGLE = "Show/Hide the USPF window.",
+	SI_BINDING_NAME_USPF_DUN_TOGGLE = "Show/Hide the USPF dungeon account window.",
 	USPF_GUI_ZN_MQ		= "Main Quest",
 
 	USPF_MSG_SHOW_GUI	= "USPF displayed.",

--- a/USPF/lang/strings.lua
+++ b/USPF/lang/strings.lua
@@ -101,6 +101,19 @@ local strings = {
 
 	USPF_QUEST_NA		= "These skill points are not quest based.",
 	USPF_QUEST_NONE		= "There are no skill point quests in this zone.",
+
+	USPF_DUN_WINDOW_TITLE	= "Dungeon skill point (account)",
+	USPF_DUN_SELECT_PD		= "-- Public dungeon --",
+	USPF_DUN_SELECT_GD		= "-- Group dungeon --",
+	USPF_DUN_LABEL_PD		= "Public dungeon",
+	USPF_DUN_LABEL_GD		= "Group dungeon",
+	USPF_DUN_LIST_BTN		= "List characters",
+	USPF_DUN_CHAR_NAME		= "Character",
+	USPF_DUN_STATUS			= "Skill point",
+	USPF_DUN_HAS_SP			= "Yes",
+	USPF_DUN_MISSING_SP		= "No",
+	USPF_DUN_UNKNOWN		= "Unknown",
+	USPF_DUN_NO_DATA		= "No saved data",
 }
 
 for stringId, stringValue in pairs(strings) do

--- a/USPF/lang/strings.lua
+++ b/USPF/lang/strings.lua
@@ -115,6 +115,9 @@ local strings = {
 	USPF_DUN_MISSING_SP		= "No",
 	USPF_DUN_UNKNOWN		= "Unknown",
 	USPF_DUN_NO_DATA		= "No saved data",
+
+	USPF_DUN_PD_SORT_DUNGEON = "Public dungeons: sort by dungeon name",
+	USPF_DUN_PD_SORT_ZONE = "Public dungeons: sort by zone name",
 }
 
 for stringId, stringValue in pairs(strings) do

--- a/USPF/lang/zh.lua
+++ b/USPF/lang/zh.lua
@@ -84,6 +84,7 @@ SafeAddString(USPF_GUI_UNASSIGNED,                                 "未分配")
 
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE,                         "显示/隐藏 USPF窗口。")
+SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE,                       "显示/隐藏 USPF 地下城账户窗口。")
 
 SafeAddString(USPF_GUI_ZN_MQ,                                      "主线任务")
 

--- a/USPF/lang/zh.lua
+++ b/USPF/lang/zh.lua
@@ -85,6 +85,8 @@ SafeAddString(USPF_GUI_UNASSIGNED,                                 "未分配")
 
 SafeAddString(SI_BINDING_NAME_USPF_TOGGLE,                         "显示/隐藏 USPF窗口。")
 SafeAddString(SI_BINDING_NAME_USPF_DUN_TOGGLE,                       "显示/隐藏 USPF 地下城账户窗口。")
+SafeAddString(USPF_DUN_PD_SORT_DUNGEON,                             "公共地下城：按地下城名称排序")
+SafeAddString(USPF_DUN_PD_SORT_ZONE,                               "公共地下城：按区域名称排序")
 
 SafeAddString(USPF_GUI_ZN_MQ,                                      "主线任务")
 


### PR DESCRIPTION
This adds a new pop-up window for skillpoints.
It focuses on just Group and Public Dungeons.
It allows the user to pick a specific dungeon and then shows which of your characaters have the skillpoint from that dungeon. 
  